### PR TITLE
Changing setOrder method declaration

### DIFF
--- a/Model/ResourceModel/Page/Fulltext/Collection.php
+++ b/Model/ResourceModel/Page/Fulltext/Collection.php
@@ -122,7 +122,7 @@ class Collection extends \Magento\Cms\Model\ResourceModel\Page\Collection
     /**
      * {@inheritDoc}
      */
-    public function setOrder($attribute, $dir = Select::SQL_DESC)
+    public function setOrder($attribute, $dir = \Magento\Framework\DB\Select::SQL_DESC)
     {
         throw new \LogicException("Sorting on multiple stores is not allowed in search engine collections.");
     }


### PR DESCRIPTION
Changed setOrder method declaration so it uses full class name for \Magento\Framework\DB\Select::SQL_DESC, before only Select part of class name was used but class was not imported and thus error was thrown.